### PR TITLE
Improve meditation pause parsing and chat UX

### DIFF
--- a/src/app/(landing)/chat/_components/bot-message.tsx
+++ b/src/app/(landing)/chat/_components/bot-message.tsx
@@ -13,10 +13,12 @@ interface BotMessageProps {
 }
 
 export function BotMessage({ message }: BotMessageProps) {
-	const [displayedText, setDisplayedText] = useState("");
+        const [displayedText, setDisplayedText] = useState("");
+        const [visible, setVisible] = useState(false);
 
-	useEffect(() => {
-		if (message.content.trim().length === 0) return;
+        useEffect(() => {
+                setVisible(true);
+                if (message.content.trim().length === 0) return;
 
 		let currentIndex = 0;
 		const text = message.content;
@@ -41,7 +43,7 @@ export function BotMessage({ message }: BotMessageProps) {
 	if (message.content.trim().length === 0) return null;
 
 	return (
-		<div className="relative pt-10">
+                <div className={cn("relative pt-10 transition-opacity duration-500", visible ? "opacity-100" : "opacity-0")}>
 			<div className="absolute top-1 flex items-center gap-1">
 				<Image
 					src="/NeijiHeadLogo1.4.png"

--- a/src/app/(landing)/chat/_components/chat.tsx
+++ b/src/app/(landing)/chat/_components/chat.tsx
@@ -5,12 +5,12 @@ import { ScrollArea } from "~/components/ui/scroll-area";
 
 export function Chat({ className, ...props }: React.ComponentProps<"div">) {
 	return (
-		<div
-			className={cn(
-				"relative mx-auto min-h-[calc(100vh-var(--spacing)*30)] max-w-2xl",
-				className,
-			)}
-			{...props}
-		/>
+                <div
+                        className={cn(
+                                "relative mx-auto min-h-[calc(100vh-var(--spacing)*30)] max-w-2xl overflow-y-auto scroll-smooth",
+                                className,
+                        )}
+                        {...props}
+                />
 	);
 }

--- a/src/app/(landing)/chat/_components/user-message.tsx
+++ b/src/app/(landing)/chat/_components/user-message.tsx
@@ -1,11 +1,22 @@
 import type * as React from "react";
+import { useState, useEffect } from "react";
+import { cn } from "~/lib/utils";
 
 export function UserMessage({ children }: { children?: React.ReactNode }) {
-	return (
-		<div className="flex justify-end">
-			<div className="max-w-xs break-all rounded-tl-xl rounded-tr-xl rounded-br-none rounded-bl-xl bg-white px-4 py-2 text-gray-800 shadow lg:max-w-md">
-				{children}
-			</div>
-		</div>
-	);
+        const [visible, setVisible] = useState(false);
+
+        useEffect(() => {
+                setVisible(true);
+        }, []);
+
+        return (
+                <div className="flex justify-end">
+                        <div className={cn(
+                                "max-w-xs break-all rounded-tl-xl rounded-tr-xl rounded-br-none rounded-bl-xl bg-white px-4 py-2 text-gray-800 shadow lg:max-w-md transition-opacity duration-500",
+                                visible ? "opacity-100" : "opacity-0",
+                        )}>
+                                {children}
+                        </div>
+                </div>
+        );
 }

--- a/src/lib/meditation/parse-text-content.ts
+++ b/src/lib/meditation/parse-text-content.ts
@@ -1,4 +1,4 @@
-import { parseDuration } from "../../../utils/parse-duration";
+import { parseDuration } from "../../utils/parse-duration";
 
 /**
  * parseTextContent(stream):
@@ -26,10 +26,10 @@ export async function* parseTextContent(stream: ReadableStream<Uint8Array>) {
 		const { value, done } = await reader.read();
 		if (done) {
 			// No more data from the stream: yield whatever text remains
-			accumulatedText += buffer;
-			if (accumulatedText.trim()) {
-				yield accumulatedText.trim();
-			}
+                        accumulatedText += buffer;
+                        if (accumulatedText) {
+                                yield accumulatedText;
+                        }
 			break;
 		}
 
@@ -37,9 +37,9 @@ export async function* parseTextContent(stream: ReadableStream<Uint8Array>) {
 		buffer += decoder.decode(value, { stream: true });
 
 		// Keep parsing while we can find a full "[pause X]" inside the buffer
-		while (true) {
-			// 1) Find the start of a pause directive
-			const startIndex = buffer.indexOf("[pause ");
+                while (true) {
+                        // 1) Find the start of a pause directive ("[pause" or "[pause:")
+                        const startIndex = buffer.indexOf("[pause");
 			if (startIndex === -1) {
 				// No (further) "[pause " in the buffer: can't parse a directive here
 				// We'll wait for more data or end-of-stream
@@ -47,33 +47,32 @@ export async function* parseTextContent(stream: ReadableStream<Uint8Array>) {
 			}
 
 			// 2) Look for the closing ']' after "[pause "
-			const endIndex = buffer.indexOf("]", startIndex);
-			if (endIndex === -1) {
-				// We have a partial directive like "[pause 3"
-				// Wait for more data in next chunk
-				break;
-			}
+                        const endIndex = buffer.indexOf("]", startIndex);
+                        if (endIndex === -1) {
+                                // We have a partial directive like "[pause 3" or "[pause: 3"
+                                // Wait for more data in next chunk
+                                break;
+                        }
 
-			// 3) We found a complete pause directive, e.g. "[pause 3]"
-			//    - Everything before `startIndex` is text to yield
+                        // 3) We found a complete pause directive, e.g. "[pause 3]" or "[pause: 3s]"
+                        //    - Everything before `startIndex` is text to yield
 			const textBefore = buffer.slice(0, startIndex);
 			accumulatedText += textBefore;
 
-			if (accumulatedText.trim()) {
-				// Yield the text we've accumulated so far, then reset it
-				yield accumulatedText.trim();
-				accumulatedText = "";
-			}
+                        if (accumulatedText) {
+                                // Yield the text we've accumulated so far, then reset it
+                                yield accumulatedText;
+                                accumulatedText = "";
+                        }
 
 			// 4) Extract the pause directive content: e.g. "[pause 3]"
-			const directive = buffer.slice(startIndex, endIndex + 1);
-			// Example: "[pause 3]"
-			// Match it to extract "3"
-			const match = directive.match(/\[pause\s+(\d+(?:\.\d+)?)\]/);
-			if (match) {
-				const seconds = parseFloat(match[1]);
-				yield seconds; // yield the numeric pause
-			}
+                        const directive = buffer.slice(startIndex, endIndex + 1);
+                        // Example: "[pause: 3s]" or "[pause 3]"
+                        const match = directive.match(/\[pause[:\s]+([^\]]+)\]/i);
+                        if (match) {
+                                const seconds = parseDuration(match[1]);
+                                yield seconds; // yield the numeric pause
+                        }
 
 			// 5) Remove the consumed portion from `buffer`
 			buffer = buffer.slice(endIndex + 1);

--- a/src/utils/parse-duration.test.ts
+++ b/src/utils/parse-duration.test.ts
@@ -1,0 +1,22 @@
+import { expect, it } from "bun:test";
+import { parseDuration } from "./parse-duration";
+
+it("parses seconds by default", () => {
+  expect(parseDuration("3")).toBe(3);
+});
+
+it("parses seconds with s suffix", () => {
+  expect(parseDuration("4s")).toBe(4);
+});
+
+it("parses minutes", () => {
+  expect(parseDuration("2m")).toBe(120);
+});
+
+it("parses hours", () => {
+  expect(parseDuration("1h")).toBe(3600);
+});
+
+it("parses milliseconds", () => {
+  expect(parseDuration("500ms")).toBeCloseTo(0.5);
+});

--- a/src/utils/parse-duration.ts
+++ b/src/utils/parse-duration.ts
@@ -1,0 +1,20 @@
+export function parseDuration(input: string): number {
+  const trimmed = input.trim().toLowerCase();
+  const match = trimmed.match(/^(\d+(?:\.\d+)?)(ms|s|m|h)?$/);
+  if (!match) {
+    const parsed = parseFloat(trimmed);
+    return isNaN(parsed) ? 0 : parsed;
+  }
+  const value = parseFloat(match[1]);
+  const unit = match[2] ?? 's';
+  switch (unit) {
+    case 'ms':
+      return value / 1000;
+    case 'm':
+      return value * 60;
+    case 'h':
+      return value * 3600;
+    default:
+      return value;
+  }
+}


### PR DESCRIPTION
## Summary
- support `[pause: 3s]` style tokens by adding a `parseDuration` util
- parse meditation content using new duration parser
- add smooth fade‑in transitions for chat messages
- enable smooth scrolling in chat container
- test duration parser

## Testing
- `bun test` *(fails: Cannot find package 'fluent-ffmpeg')*

------
https://chatgpt.com/codex/tasks/task_e_68505a2fc638832e804a0cc45bbc2aed